### PR TITLE
Replace fixed offsets with patterns

### DIFF
--- a/GGXrdReversalTool.Library/Configuration/ReversalToolConfigObject.cs
+++ b/GGXrdReversalTool.Library/Configuration/ReversalToolConfigObject.cs
@@ -13,41 +13,11 @@ public class ReversalToolConfigObject
     [JsonPropertyName("P2IdOffset")]
     public string P2IdOffset { get; set; }
 
-    [JsonPropertyName("RecordingSlotPtr")]
-    public string RecordingSlotPtr { get; set; }
-
-    [JsonPropertyName("P1AnimStringPtr")]
-    public string P1AnimStringPtr { get; set; }
-
-    [JsonPropertyName("P2AnimStringPtr")]
-    public string P2AnimStringPtr { get; set; }
-
-    [JsonPropertyName("FrameCountPtr")]
-    public string FrameCountPtr { get; set; }
-
     [JsonPropertyName("ScriptOffset")]
     public string ScriptOffset { get; set; }
 
-    [JsonPropertyName("P1ComboCountPtr")]
-    public string P1ComboCountPtr { get; set; }
-
-    [JsonPropertyName("P2ComboCountPtr")]
-    public string P2ComboCountPtr { get; set; }
-
     [JsonPropertyName("UpdateLink")]
     public string UpdateLink { get; set; }
-
-    [JsonPropertyName("DummyIdPtr")]
-    public string DummyIdPtr { get; set; }
-
-    [JsonPropertyName("P1ReplayKeyPtr")]
-    public string P1ReplayKeyPtr { get; set; }
-
-    [JsonPropertyName("P2ReplayKeyPtr")]
-    public string P2ReplayKeyPtr { get; set; }
-
-    [JsonPropertyName("P2BlockStunPtr")]
-    public string P2BlockStunPtr { get; set; }
 
     [JsonPropertyName("ReplayTriggerType")]
     public string ReplayTriggerType { get; set; }

--- a/GGXrdReversalTool.Library/Memory/Pointer/MemoryPointer.cs
+++ b/GGXrdReversalTool.Library/Memory/Pointer/MemoryPointer.cs
@@ -12,7 +12,19 @@ public class MemoryPointer
     public string Name { get; }
 
 
-    public MemoryPointer(string name, string value)
+    public MemoryPointer(string name, IEnumerable<int> offsets)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Memory pointer should have a name", nameof(name));
+        }
+
+        Name = name;
+        Pointer = new IntPtr(offsets.First());
+        Offsets = new List<int>(offsets.Skip(1));
+    }
+
+    public MemoryPointer(string name, string value, IntPtr baseAddress)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -44,7 +56,7 @@ public class MemoryPointer
             throw new ArgumentException($"Pointer {name} value is invalid", nameof(value));
         }
 
-        Pointer = new IntPtr(pointerValue);
+        Pointer = baseAddress + pointerValue;
 
         Offsets = values.Skip(1).Select(offset =>
         {
@@ -63,8 +75,8 @@ public class MemoryPointer
 
     }
 
-    public MemoryPointer(string name)
-        : this(name, ReversalToolConfiguration.Get(name))
+    public MemoryPointer(string name, IntPtr baseAddress)
+        : this(name, ReversalToolConfiguration.Get(name), baseAddress)
     {
     }
 }

--- a/GGXrdReversalTool/appsettings.json
+++ b/GGXrdReversalTool/appsettings.json
@@ -9,24 +9,9 @@
     "GGProcessName": "GuiltyGearXrd",
     "P2IdOffset" : "0",
 
-    "RecordingSlotPtr" : "0x00BC1E5C|0x0",
-
-    "P1AnimStringPtr" : "0x01B22358|0x2444",
-    "P2AnimStringPtr" : "0x01B2235C|0x2444",
-    "FrameCountPtr" : "0x009BB3BC|0x0",
-
     "ScriptOffset" : "0",
 
-    "P1ComboCountPtr" : "0x01B2235C|0x9F28",
-    "P2ComboCountPtr" : "0",
-
     "UpdateLink" : "https://github.com/Iquis/rev2-wakeup-tool/releases",
-    "DummyIdPtr" : "0x00BEBA54|0x200",
-
-    "P1ReplayKeyPtr" : "0x00BDF110|0x40",
-    "P2ReplayKeyPtr" : "0x00BDF110|0x90",
-
-    "P2BlockStunPtr" : "0x01B2235C|0x4D54",
 
     "ReplayTriggerType" : "AsmInjection",
 


### PR DESCRIPTION
Extracted all current pointers from the machine code using byte sequences not containing relocations.  The existing framework for parsing offset strings should still work alongside the new system.

I may have also fixed some 32-bit pointer handling somewhere in MemoryReader, as at one point I was getting an erroneous 64-bit pointer from existing code.