### PR TITLE
Support training on P2 side

### DIFF
--- a/GGXrdReversalTool.Library/Memory/IMemoryReader.cs
+++ b/GGXrdReversalTool.Library/Memory/IMemoryReader.cs
@@ -13,7 +13,9 @@ public interface IMemoryReader
     Character GetCurrentDummy();
     bool WriteInputInSlot(int slotNumber, SlotInput slotInput);
     int GetComboCount(int player);
-    int GetReplayKeyCode(int player);
+    int GetReplayKeyCode();
     int GetBlockstun(int player);
+    int GetPlayerSide();
+    bool IsTrainingMode();
     Process Process { get; }
 }

--- a/GGXrdReversalTool.Library/Scenarios/Action/Implementations/PlayReversalAction.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Action/Implementations/PlayReversalAction.cs
@@ -74,7 +74,7 @@ public class PlayReversalAction : IScenarioAction
     
     private DirectXKeyStrokes GetReplayKeyStroke()
     {
-        int replayKeyCode = MemoryReader.GetReplayKeyCode(1);
+        int replayKeyCode = MemoryReader.GetReplayKeyCode();
 
         return (DirectXKeyStrokes)MapVirtualKeyEx((uint)replayKeyCode, MapVirtualKeyMapTypes.MAPVK_VK_TO_VSC, GetKeyboardLayout(0));
     }

--- a/GGXrdReversalTool.Library/Scenarios/Event/Implementations/AnimationEvent.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Event/Implementations/AnimationEvent.cs
@@ -27,7 +27,7 @@ public class AnimationEvent : IScenarioEvent
 
     public EventAnimationInfo CheckEvent()
     {
-        var animationString = MemoryReader.ReadAnimationString(2);
+        var animationString = MemoryReader.ReadAnimationString(1 - MemoryReader.GetPlayerSide());
 
         var result = animationString switch
         {
@@ -36,7 +36,7 @@ public class AnimationEvent : IScenarioEvent
             WallSplatAnimation when ShouldCheckWallSplat => new EventAnimationInfo(AnimationEventTypes.WallSplat),
             TechAnimation when ShouldCheckAirTech => new EventAnimationInfo(AnimationEventTypes.Tech),
             CrouchBlockingAnimation or StandBlockingAnimation or HighBlockingAnimation when ShouldCheckStartBlocking && _lastAnimationString is not (CrouchBlockingAnimation or StandBlockingAnimation or HighBlockingAnimation) => new EventAnimationInfo(AnimationEventTypes.StartBlocking, 0),
-            CrouchBlockingAnimation or StandBlockingAnimation or HighBlockingAnimation when ShouldCheckBlockstunEnding => new EventAnimationInfo(AnimationEventTypes.EndBlocking, MemoryReader.GetBlockstun(2)),
+            CrouchBlockingAnimation or StandBlockingAnimation or HighBlockingAnimation when ShouldCheckBlockstunEnding => new EventAnimationInfo(AnimationEventTypes.EndBlocking, MemoryReader.GetBlockstun(1 - MemoryReader.GetPlayerSide())),
             _ => new EventAnimationInfo()
         };
 

--- a/GGXrdReversalTool.Library/Scenarios/Event/Implementations/ComboEvent.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Event/Implementations/ComboEvent.cs
@@ -15,7 +15,7 @@ public class ComboEvent : IScenarioEvent
 
     public EventAnimationInfo CheckEvent()
     {
-        var comboCount = MemoryReader.GetComboCount(1);
+        var comboCount = MemoryReader.GetComboCount(MemoryReader.GetPlayerSide());
 
         if (comboCount >= MinComboCount && comboCount<= MaxComboCount && _oldComboCount != comboCount)
         {


### PR DESCRIPTION
I feel like IMemoryReader methods should be requesting player or dummy data rather than p1 or p2 but that's not a design decision for me.