### PR TITLE
Fixing Preset.cs

### DIFF
--- a/GGXrdReversalTool.Library/Presets/Preset.cs
+++ b/GGXrdReversalTool.Library/Presets/Preset.cs
@@ -23,8 +23,8 @@ public class Preset
                 new CharacterMove { Name = "FD Jump", Input = "!7,1PK*200"},
                 new CharacterMove { Name = "FD Superjump", Input = "!2,7,1PK*200"},
                 new CharacterMove { Name = "Gold Burst", Input = "!5DH"},
-                new CharacterMove { Name = "Throw + 6P OS", Input = "!6PH"},
-                new CharacterMove { Name = "Throw + cS OS", Input = "!6SH"}
+                new CharacterMove { Name = "Throw + 6P OS", Input = "!6PH*3"},
+                new CharacterMove { Name = "Throw + cS OS", Input = "!6SH*3"}
 
             }
         },


### PR DESCRIPTION
Fixing the throw + 6P/cS OS to work correctly, for some reason this is how it works:


```
!6PH gives blitz on wakeup and throw if youre close and not the OS "properly"
!6PH*2 does the same
!6PH*3 gives the throw OS on wakeup correctly 
``` 