### PR TITLE
Play slots in order

### DIFF
--- a/GGXrdReversalTool.Library/Memory/IMemoryReader.cs
+++ b/GGXrdReversalTool.Library/Memory/IMemoryReader.cs
@@ -29,6 +29,7 @@ public interface IMemoryReader
     bool IsTrainingMode();
     public bool IsWorldInTick();
     public uint GetEngineTickCount();
+    public bool MatchRunning();
     public uint GetAswEngineTickCount();
 
     Process Process { get; }

--- a/GGXrdReversalTool.Library/Memory/Implementations/MemoryReader.cs
+++ b/GGXrdReversalTool.Library/Memory/Implementations/MemoryReader.cs
@@ -17,8 +17,6 @@ public class MemoryReader : IMemoryReader
         _pointerCollection = new MemoryPointerCollection(process, this);
     }
 
-    private const int RecordingSlotSize = 4808;
-
     private readonly MemoryPointerCollection _pointerCollection;
 
     public Process Process { get; }
@@ -73,9 +71,9 @@ public class MemoryReader : IMemoryReader
         }
 
         var baseAddress = GetAddressWithOffsets(_pointerCollection.RecordingSlotPtr);
-        var slotAddress = IntPtr.Add(baseAddress, RecordingSlotSize * (slotNumber - 1));
+        var slotAddress = IntPtr.Add(baseAddress, SlotInput.RecordingSlotSize * (slotNumber - 1));
 
-        return Write(slotAddress, slotInput.Header.Concat(slotInput.Content));
+        return Write(slotAddress, slotInput.HeaderCapped.Concat(slotInput.Content).Take(SlotInput.RecordingSlotSize / 2));
     }
 
     public void LockDummy(int player, out uint oldFlags)
@@ -137,9 +135,9 @@ public class MemoryReader : IMemoryReader
         }
 
         var baseAddress = GetAddressWithOffsets(_pointerCollection.RecordingSlotPtr);
-        var slotAddress = IntPtr.Add(baseAddress, RecordingSlotSize * (slotNumber - 1));
+        var slotAddress = IntPtr.Add(baseAddress, SlotInput.RecordingSlotSize * (slotNumber - 1));
 
-        var readBytes = ReadBytes(slotAddress, RecordingSlotSize);
+        var readBytes = ReadBytes(slotAddress, SlotInput.RecordingSlotSize);
 
 
         var inputLength = byte.MaxValue * readBytes[5] + readBytes[4];

--- a/GGXrdReversalTool.Library/Memory/Implementations/MemoryReader.cs
+++ b/GGXrdReversalTool.Library/Memory/Implementations/MemoryReader.cs
@@ -95,9 +95,9 @@ public class MemoryReader : IMemoryReader
         Write(_pointerCollection.Players[player].WhatCanDoFlagsPtr, (int)oldFlags);
     }
     public int GetTimeUntilTech(int player) =>
-    	player is < 0 or > 1
-    	? 0
-    	: Read<int>(_pointerCollection.Players[player].TimeUntilTechPtr);
+        player is < 0 or > 1
+        ? 0
+        : Read<int>(_pointerCollection.Players[player].TimeUntilTechPtr);
     public bool GetTechRelatedFlag(int player)
     {
         if (player is < 0 or > 1)

--- a/GGXrdReversalTool.Library/Memory/Implementations/MemoryReader.cs
+++ b/GGXrdReversalTool.Library/Memory/Implementations/MemoryReader.cs
@@ -244,6 +244,7 @@ public class MemoryReader : IMemoryReader
     }
 
     public uint GetAswEngineTickCount() => Read<uint>(_pointerCollection.AswEngineTickCountPtr);
+    public bool MatchRunning() => Read<bool>(_pointerCollection.MatchRunningPtr);
 
 
     #region DLL Imports
@@ -428,6 +429,7 @@ public class MemoryReader : IMemoryReader
         public MemoryPointer WorldInTickPtr { get; private set; } = null!;
         public MemoryPointer EngineTickCountPtr { get; private set; } = null!;
         public MemoryPointer AswEngineTickCountPtr { get; private set; } = null!;
+        public MemoryPointer MatchRunningPtr { get; private set; } = null!;
         public MemoryPointer AirRecoverySettingPtr { get; private set; } = null!;
 
         private readonly Process _process;
@@ -495,6 +497,7 @@ public class MemoryReader : IMemoryReader
             EngineTickCountPtr = new MemoryPointer(_memoryReader.Read<int>(textAddr - 4 + FindPatternOffset(text, engineTickCountPattern)));
             
             AswEngineTickCountPtr = new MemoryPointer(matchPtrAddr, 0x1c6f70);
+            MatchRunningPtr = new MemoryPointer(matchPtrAddr, 0x1c7320);
 
             const string airRecoverySettingPattern = "i0wkBIPB7jPAg/kVD4e0AAAA";
             AirRecoverySettingPtr = new MemoryPointer(_memoryReader.Read<int>(textAddr + 0x9A + FindPatternOffset(text, airRecoverySettingPattern)));

--- a/GGXrdReversalTool.Library/Models/Inputs/SlotInput.cs
+++ b/GGXrdReversalTool.Library/Models/Inputs/SlotInput.cs
@@ -6,6 +6,7 @@ namespace GGXrdReversalTool.Library.Models.Inputs;
 
 public class SlotInput
 {
+	public const int RecordingSlotSize = 4808;
     private const char FrameDelimiter = ',';
     private const char WakeUpFrameDelimiter = '!';
     private const int WakeupFrameMask = 0x200;
@@ -187,6 +188,7 @@ public class SlotInput
 
 
     public IEnumerable<ushort> Header => new List<ushort> { 0, 0, (ushort)Content.Count(), 0 };
+    public IEnumerable<ushort> HeaderCapped => new List<ushort> { 0, 0, (ushort)Math.Min(  Content.Count(), (RecordingSlotSize - 8) / 2  ), 0	};
 
     private string SingleInputParse(ushort input, bool isP2 = false)
     {

--- a/GGXrdReversalTool.Library/Scenarios/Event/Implementations/AnimationEvent.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Event/Implementations/AnimationEvent.cs
@@ -40,7 +40,7 @@ public class AnimationEvent : IScenarioEvent
         
         if (isUserControllingDummy)
         {
-        	return int.MaxValue;
+            return int.MaxValue;
         }
         var currentDummy = MemoryReader.GetCurrentDummy();
         var animationString = MemoryReader.ReadAnimationString(dummySide);

--- a/GGXrdReversalTool.Library/Scenarios/Frequency/IScenarioFrequency.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Frequency/IScenarioFrequency.cs
@@ -13,4 +13,5 @@ public interface IScenarioFrequency
     bool ShouldHappen(out int slotNumber);
     IMemoryReader? MemoryReader { get; internal set; }
     int[] UsedSlotNumbers();
+    void onStageReset();
 }

--- a/GGXrdReversalTool.Library/Scenarios/Frequency/Implementations/PercentageFrequency.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Frequency/Implementations/PercentageFrequency.cs
@@ -8,6 +8,7 @@ public class PercentageFrequency : IScenarioFrequency
     private int _percentage = 100;
     private bool _playRandomSlot = false;
     private bool _playSlotsInOrder = false;
+    private bool _resetOnStageReset = false;
     private int _playSlotsInOrderNext = 1;
     private bool _useSlot1 = false;
     private bool _useSlot2 = false;
@@ -50,6 +51,12 @@ public class PercentageFrequency : IScenarioFrequency
     {
         get => _playSlotsInOrder;
         set => _playSlotsInOrder = value;
+    }
+    
+    public bool ResetOnStageReset
+    {
+        get => _resetOnStageReset;
+        set => _resetOnStageReset = value;
     }
     
     public bool UseSlot1
@@ -201,6 +208,9 @@ public class PercentageFrequency : IScenarioFrequency
     
     public void onStageReset()
     {
-        _playSlotsInOrderNext = 1;
+        if (_resetOnStageReset)
+        {
+            _playSlotsInOrderNext = 1;
+        }
     }
 }

--- a/GGXrdReversalTool.Library/Scenarios/Frequency/Implementations/PercentageFrequency.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Frequency/Implementations/PercentageFrequency.cs
@@ -7,6 +7,8 @@ public class PercentageFrequency : IScenarioFrequency
     private readonly Random _random = new();
     private int _percentage = 100;
     private bool _playRandomSlot = false;
+    private bool _playSlotsInOrder = false;
+    private int _playSlotsInOrderNext = 1;
     private bool _useSlot1 = false;
     private bool _useSlot2 = false;
     private bool _useSlot3 = false;
@@ -44,6 +46,12 @@ public class PercentageFrequency : IScenarioFrequency
         set => _playRandomSlot = value;
     }
     
+    public bool PlaySlotsInOrder
+    {
+        get => _playSlotsInOrder;
+        set => _playSlotsInOrder = value;
+    }
+    
     public bool UseSlot1
     {
         get => _useSlot1;
@@ -66,9 +74,14 @@ public class PercentageFrequency : IScenarioFrequency
     public bool ShouldHappen(out int slotNumber)
     {
         slotNumber = -1;
-        if (!_playRandomSlot)
+    	bool mainChanceOk = _random.Next(1, 101) <= _percentage;
+    	if (!_playRandomSlot && !mainChanceOk)
+    	{
+    		return false;
+    	}
+        if (!_playRandomSlot && !_playSlotsInOrder)
         {
-            return _random.Next(1, 101) <= _percentage;
+        	return true;
         }
         
         int[] slotNumbers = new int[3];
@@ -98,6 +111,40 @@ public class PercentageFrequency : IScenarioFrequency
             slotNumbers[slotCount] = 3;
             slotChances[slotCount] = _slot3Percentage;
             ++slotCount;
+        }
+        
+        if (_playSlotsInOrder)
+        {
+        	for (int i = 0; i < slotCount; ++i)
+        	{
+        		if (slotNumbers[i] == _playSlotsInOrderNext)
+        		{
+        			slotNumber = _playSlotsInOrderNext;
+        			if (i < slotCount - 1)
+        			{
+        				_playSlotsInOrderNext = slotNumbers[i + 1];
+        			}
+        			else
+        			{
+        				_playSlotsInOrderNext = slotNumbers[0];
+        			}
+        			return true;
+        		}
+        	}
+        	if (slotCount == 0)
+        	{
+        		return false;
+        	}
+    		slotNumber = slotNumbers[0];
+    		if (slotCount == 1)
+    		{
+    			_playSlotsInOrderNext = slotNumber;
+    		}
+    		else
+    		{
+    			_playSlotsInOrderNext = slotNumbers[1];
+    		}
+    		return true;
         }
         
         if (summaryChance < 100)
@@ -133,7 +180,7 @@ public class PercentageFrequency : IScenarioFrequency
     public int[] UsedSlotNumbers()
     {
         int[] array;
-        if (!_playRandomSlot) {
+        if (!_playRandomSlot && !_playSlotsInOrder) {
             array = new int[1];
             array[0] = -1;
             return array;
@@ -151,4 +198,9 @@ public class PercentageFrequency : IScenarioFrequency
         if (_useSlot3) array[count++] = 3;
         return array;
     }
+    
+    public void onStageReset()
+	{
+		_playSlotsInOrderNext = 1;
+	}
 }

--- a/GGXrdReversalTool.Library/Scenarios/Frequency/Implementations/PercentageFrequency.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Frequency/Implementations/PercentageFrequency.cs
@@ -74,14 +74,14 @@ public class PercentageFrequency : IScenarioFrequency
     public bool ShouldHappen(out int slotNumber)
     {
         slotNumber = -1;
-    	bool mainChanceOk = _random.Next(1, 101) <= _percentage;
-    	if (!_playRandomSlot && !mainChanceOk)
-    	{
-    		return false;
-    	}
+        bool mainChanceOk = _random.Next(1, 101) <= _percentage;
+        if (!_playRandomSlot && !mainChanceOk)
+        {
+            return false;
+        }
         if (!_playRandomSlot && !_playSlotsInOrder)
         {
-        	return true;
+            return true;
         }
         
         int[] slotNumbers = new int[3];
@@ -115,36 +115,36 @@ public class PercentageFrequency : IScenarioFrequency
         
         if (_playSlotsInOrder)
         {
-        	for (int i = 0; i < slotCount; ++i)
-        	{
-        		if (slotNumbers[i] == _playSlotsInOrderNext)
-        		{
-        			slotNumber = _playSlotsInOrderNext;
-        			if (i < slotCount - 1)
-        			{
-        				_playSlotsInOrderNext = slotNumbers[i + 1];
-        			}
-        			else
-        			{
-        				_playSlotsInOrderNext = slotNumbers[0];
-        			}
-        			return true;
-        		}
-        	}
-        	if (slotCount == 0)
-        	{
-        		return false;
-        	}
-    		slotNumber = slotNumbers[0];
-    		if (slotCount == 1)
-    		{
-    			_playSlotsInOrderNext = slotNumber;
-    		}
-    		else
-    		{
-    			_playSlotsInOrderNext = slotNumbers[1];
-    		}
-    		return true;
+            for (int i = 0; i < slotCount; ++i)
+            {
+                if (slotNumbers[i] == _playSlotsInOrderNext)
+                {
+                    slotNumber = _playSlotsInOrderNext;
+                    if (i < slotCount - 1)
+                    {
+                        _playSlotsInOrderNext = slotNumbers[i + 1];
+                    }
+                    else
+                    {
+                        _playSlotsInOrderNext = slotNumbers[0];
+                    }
+                    return true;
+                }
+            }
+            if (slotCount == 0)
+            {
+                return false;
+            }
+            slotNumber = slotNumbers[0];
+            if (slotCount == 1)
+            {
+                _playSlotsInOrderNext = slotNumber;
+            }
+            else
+            {
+                _playSlotsInOrderNext = slotNumbers[1];
+            }
+            return true;
         }
         
         if (summaryChance < 100)
@@ -200,7 +200,7 @@ public class PercentageFrequency : IScenarioFrequency
     }
     
     public void onStageReset()
-	{
-		_playSlotsInOrderNext = 1;
-	}
+    {
+        _playSlotsInOrderNext = 1;
+    }
 }

--- a/GGXrdReversalTool.Library/Scenarios/Scenario.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Scenario.cs
@@ -124,6 +124,10 @@ public class Scenario : IDisposable
                 prevAswEngineTicks = aswEngineTicks;
                 aswEngineTicks = _memoryReader.GetAswEngineTickCount();
                 if (aswEngineTicks == prevAswEngineTicks) continue;
+                if (!_memoryReader.MatchRunning())  // stage reset?
+                {
+                	_scenarioFrequency.onStageReset();
+                }
                 
                 if (_scenarioAction.IsRunning)
                 {

--- a/GGXrdReversalTool.Library/Scenarios/Scenario.cs
+++ b/GGXrdReversalTool.Library/Scenarios/Scenario.cs
@@ -126,7 +126,7 @@ public class Scenario : IDisposable
                 if (aswEngineTicks == prevAswEngineTicks) continue;
                 if (!_memoryReader.MatchRunning())  // stage reset?
                 {
-                	_scenarioFrequency.onStageReset();
+                    _scenarioFrequency.onStageReset();
                 }
                 
                 if (_scenarioAction.IsRunning)

--- a/GGXrdReversalTool/Controls/ActionControl.xaml
+++ b/GGXrdReversalTool/Controls/ActionControl.xaml
@@ -35,10 +35,12 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <Image Grid.Column="0" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5" Source="../Images/info.png" Height="16" ToolTipService.ToolTip="Sequences shorter than 5f cannot be used with the in-game, built-in Random slot playback (but can in this mod's random playback)." Visibility="{Binding TooShortInfoVisible, ElementName=Control}"/>
                     <Image Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5" Source="../Images/info.png" Height="16" ToolTipService.ToolTip="The &quot;!&quot; character doesn't affect anything and is not needed in the currently selected &quot;When&quot; mode." Visibility="{Binding NoNeedStartMarkerInfoVisible, ElementName=Control}"/>
                     <Image Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5" Source="../Images/warning.png" Height="16" ToolTipService.ToolTip="Missing &quot;!&quot; character, denoting the reversal frame." Visibility="{Binding NoStartMarkerWarningVisible, ElementName=Control}"/>
+                    <Image Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5" Source="../Images/warning.png" Height="16" ToolTipService.ToolTip="The input sequence is too long and will only partially be written." Visibility="{Binding TooLongMarkerWarningVisible, ElementName=Control}"/>
                 </Grid>
                 <local:PresetMenu Grid.Column="1" Margin="0,5" InsertPresetInputCommand="{Binding ElementName=Control, Path=InsertPresetInputCommand}"/>
             </Grid>

--- a/GGXrdReversalTool/Controls/ActionControl.xaml.cs
+++ b/GGXrdReversalTool/Controls/ActionControl.xaml.cs
@@ -57,6 +57,18 @@ public sealed partial class ActionControl
         }
     }
     
+    private Visibility _tooLongMarkerWarningVisible = Visibility.Collapsed;
+    public Visibility TooLongMarkerWarningVisible
+    {
+        get => _tooLongMarkerWarningVisible;
+        set
+        {
+            if (value == _tooLongMarkerWarningVisible) return;
+            _tooLongMarkerWarningVisible = value;
+            OnPropertyChanged();
+        }
+    }
+    
     private Visibility _noNeedStartMarkerInfoVisible = Visibility.Collapsed;
     public Visibility NoNeedStartMarkerInfoVisible
     {
@@ -276,6 +288,7 @@ public sealed partial class ActionControl
         UpdateTooShort();
         UpdateMissingStart();
         UpdateNoNeedStart();
+        UpdateTooLong();
     }
     
     private void UpdateTooShort()
@@ -307,6 +320,20 @@ public sealed partial class ActionControl
             NoStartMarkerWarningVisible = Visibility.Visible;
         } else {
             NoStartMarkerWarningVisible = Visibility.Collapsed;
+        }
+    }
+    
+    private void UpdateTooLong()
+    {
+        if (RawInputText.Length == 0) {
+            TooLongMarkerWarningVisible = Visibility.Collapsed;
+            return;
+        }
+        SlotInput testSlot = new SlotInput(RawInputText);
+        if (testSlot.Header.Count() + testSlot.Content.Count() > SlotInput.RecordingSlotSize) {
+            TooLongMarkerWarningVisible = Visibility.Visible;
+        } else {
+            TooLongMarkerWarningVisible = Visibility.Collapsed;
         }
     }
     

--- a/GGXrdReversalTool/Controls/FrequencyControl.xaml
+++ b/GGXrdReversalTool/Controls/FrequencyControl.xaml
@@ -20,10 +20,23 @@
             </Grid.RowDefinitions>
             <TextBlock TextWrapping="Wrap" Text="{Binding ElementName=Control, Path=Percentage, Converter={StaticResource PercentageFrequencyConverter}}" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource AntiVisibilityCollapsedConverter}}"/>
             <Slider Grid.Row="1" Value="{Binding ElementName=Control, Path=Percentage}" Minimum="0" Maximum="100" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource AntiVisibilityCollapsedConverter}}"/>
-            <CheckBox Content="Play a random slot" IsChecked="{Binding ElementName=Control, Path=PlayRandomSlot}" Margin="5" HorizontalAlignment="Left" Grid.Row="2" VerticalAlignment="Center"/>
-            <local:FrequencyRandomSlotControl Grid.Row="3" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource VisibilityCollapsedConverter}}" SlotNumber="1" UseSlot="{Binding ElementName=Control, Path=UseSlot1, Mode=OneWayToSource}" SlotPercentage="{Binding ElementName=Control, Path=Slot1Percentage, Mode=TwoWay}"/>
-            <local:FrequencyRandomSlotControl Grid.Row="4" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource VisibilityCollapsedConverter}}" SlotNumber="2" UseSlot="{Binding ElementName=Control, Path=UseSlot2, Mode=OneWayToSource}" SlotPercentage="{Binding ElementName=Control, Path=Slot2Percentage, Mode=TwoWay}"/>
-            <local:FrequencyRandomSlotControl Grid.Row="5" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource VisibilityCollapsedConverter}}" SlotNumber="3" UseSlot="{Binding ElementName=Control, Path=UseSlot3, Mode=OneWayToSource}" SlotPercentage="{Binding ElementName=Control, Path=Slot3Percentage, Mode=TwoWay}"/>
+            <Grid HorizontalAlignment="Left" Grid.Row="2" VerticalAlignment="Center">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <CheckBox Grid.Column="0" Content="Play a random slot" IsChecked="{Binding ElementName=Control, Path=PlayRandomSlot}" Margin="5" HorizontalAlignment="Left" Grid.Row="2" VerticalAlignment="Center"/>
+                <CheckBox Grid.Column="1" Content="Play slots in order" IsChecked="{Binding ElementName=Control, Path=PlaySlotsInOrder}" Margin="5" HorizontalAlignment="Left" Grid.Row="2" VerticalAlignment="Center"/>
+            </Grid>
+            <local:FrequencyRandomSlotControl Grid.Row="3" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource VisibilityCollapsedConverter}}" SlotNumber="1" UseSlot="{Binding ElementName=Control, Path=UseSlot1, Mode=TwoWay}" SlotPercentage="{Binding ElementName=Control, Path=Slot1Percentage, Mode=TwoWay}"/>
+            <local:FrequencyRandomSlotControl Grid.Row="4" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource VisibilityCollapsedConverter}}" SlotNumber="2" UseSlot="{Binding ElementName=Control, Path=UseSlot2, Mode=TwoWay}" SlotPercentage="{Binding ElementName=Control, Path=Slot2Percentage, Mode=TwoWay}"/>
+            <local:FrequencyRandomSlotControl Grid.Row="5" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource VisibilityCollapsedConverter}}" SlotNumber="3" UseSlot="{Binding ElementName=Control, Path=UseSlot3, Mode=TwoWay}" SlotPercentage="{Binding ElementName=Control, Path=Slot3Percentage, Mode=TwoWay}"/>
+            <CheckBox Grid.Row="3" Content="Use slot 1" Visibility="{Binding ElementName=Control, Path=PlaySlotsInOrder, Converter={StaticResource VisibilityCollapsedConverter}}" IsChecked="{Binding ElementName=Control, Path=UseSlot1, Mode=TwoWay}" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+            <CheckBox Grid.Row="4" Content="Use slot 2" Visibility="{Binding ElementName=Control, Path=PlaySlotsInOrder, Converter={StaticResource VisibilityCollapsedConverter}}" IsChecked="{Binding ElementName=Control, Path=UseSlot2, Mode=TwoWay}" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+            <CheckBox Grid.Row="5" Content="Use slot 3" Visibility="{Binding ElementName=Control, Path=PlaySlotsInOrder, Converter={StaticResource VisibilityCollapsedConverter}}" IsChecked="{Binding ElementName=Control, Path=UseSlot3, Mode=TwoWay}" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center"/>
         </Grid>
     </GroupBox>
 </local:NotifiedUserControl>

--- a/GGXrdReversalTool/Controls/FrequencyControl.xaml
+++ b/GGXrdReversalTool/Controls/FrequencyControl.xaml
@@ -17,6 +17,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <TextBlock TextWrapping="Wrap" Text="{Binding ElementName=Control, Path=Percentage, Converter={StaticResource PercentageFrequencyConverter}}" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource AntiVisibilityCollapsedConverter}}"/>
             <Slider Grid.Row="1" Value="{Binding ElementName=Control, Path=Percentage}" Minimum="0" Maximum="100" Visibility="{Binding ElementName=Control, Path=PlayRandomSlot, Converter={StaticResource AntiVisibilityCollapsedConverter}}"/>
@@ -37,6 +38,7 @@
             <CheckBox Grid.Row="3" Content="Use slot 1" Visibility="{Binding ElementName=Control, Path=PlaySlotsInOrder, Converter={StaticResource VisibilityCollapsedConverter}}" IsChecked="{Binding ElementName=Control, Path=UseSlot1, Mode=TwoWay}" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center"/>
             <CheckBox Grid.Row="4" Content="Use slot 2" Visibility="{Binding ElementName=Control, Path=PlaySlotsInOrder, Converter={StaticResource VisibilityCollapsedConverter}}" IsChecked="{Binding ElementName=Control, Path=UseSlot2, Mode=TwoWay}" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center"/>
             <CheckBox Grid.Row="5" Content="Use slot 3" Visibility="{Binding ElementName=Control, Path=PlaySlotsInOrder, Converter={StaticResource VisibilityCollapsedConverter}}" IsChecked="{Binding ElementName=Control, Path=UseSlot3, Mode=TwoWay}" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+            <CheckBox Grid.Row="6" Content="Reset on stage reset" ToolTipService.ToolTip="When the stage resets, the order of playback will restart from the first slot." Visibility="{Binding ElementName=Control, Path=PlaySlotsInOrder, Converter={StaticResource VisibilityCollapsedConverter}}" IsChecked="{Binding ElementName=Control, Path=ResetOnStageReset, Mode=TwoWay}" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center"/>
         </Grid>
     </GroupBox>
 </local:NotifiedUserControl>

--- a/GGXrdReversalTool/Controls/FrequencyControl.xaml.cs
+++ b/GGXrdReversalTool/Controls/FrequencyControl.xaml.cs
@@ -36,8 +36,8 @@ public sealed partial class FrequencyControl : NotifiedUserControl
             _playRandomSlot = value;
             OnPropertyChanged();
             if (_playRandomSlot && _playSlotsInOrder) {
-            	_playSlotsInOrder = false;
-            	OnPropertyChanged("PlaySlotsInOrder");
+                _playSlotsInOrder = false;
+                OnPropertyChanged("PlaySlotsInOrder");
             }
             CreateScenario();
         }
@@ -53,8 +53,8 @@ public sealed partial class FrequencyControl : NotifiedUserControl
             _playSlotsInOrder = value;
             OnPropertyChanged();
             if (_playSlotsInOrder && _playRandomSlot) {
-            	_playRandomSlot = false;
-            	OnPropertyChanged("PlayRandomSlot");
+                _playRandomSlot = false;
+                OnPropertyChanged("PlayRandomSlot");
             }
             CreateScenario();
         }

--- a/GGXrdReversalTool/Controls/FrequencyControl.xaml.cs
+++ b/GGXrdReversalTool/Controls/FrequencyControl.xaml.cs
@@ -35,6 +35,27 @@ public sealed partial class FrequencyControl : NotifiedUserControl
             if (value == _playRandomSlot) return;
             _playRandomSlot = value;
             OnPropertyChanged();
+            if (_playRandomSlot && _playSlotsInOrder) {
+            	_playSlotsInOrder = false;
+            	OnPropertyChanged("PlaySlotsInOrder");
+            }
+            CreateScenario();
+        }
+    }
+
+    private bool _playSlotsInOrder = false;
+    public bool PlaySlotsInOrder
+    {
+        get => _playSlotsInOrder;
+        set
+        {
+            if (value == _playSlotsInOrder) return;
+            _playSlotsInOrder = value;
+            OnPropertyChanged();
+            if (_playSlotsInOrder && _playRandomSlot) {
+            	_playRandomSlot = false;
+            	OnPropertyChanged("PlayRandomSlot");
+            }
             CreateScenario();
         }
     }
@@ -159,6 +180,7 @@ public sealed partial class FrequencyControl : NotifiedUserControl
         {
             Percentage = Percentage,
             PlayRandomSlot = PlayRandomSlot,
+            PlaySlotsInOrder = PlaySlotsInOrder,
             UseSlot1 = UseSlot1,
             UseSlot2 = UseSlot2,
             UseSlot3 = UseSlot3,

--- a/GGXrdReversalTool/Controls/FrequencyControl.xaml.cs
+++ b/GGXrdReversalTool/Controls/FrequencyControl.xaml.cs
@@ -60,6 +60,19 @@ public sealed partial class FrequencyControl : NotifiedUserControl
         }
     }
 
+    private bool _resetOnStageReset = false;
+    public bool ResetOnStageReset
+    {
+        get => _resetOnStageReset;
+        set
+        {
+            if (value == _resetOnStageReset) return;
+            _resetOnStageReset = value;
+            OnPropertyChanged();
+            CreateScenario();
+        }
+    }
+
     private int _slot1Percentage = 100;
     public int Slot1Percentage
     {
@@ -181,6 +194,7 @@ public sealed partial class FrequencyControl : NotifiedUserControl
             Percentage = Percentage,
             PlayRandomSlot = PlayRandomSlot,
             PlaySlotsInOrder = PlaySlotsInOrder,
+            ResetOnStageReset = ResetOnStageReset,
             UseSlot1 = UseSlot1,
             UseSlot2 = UseSlot2,
             UseSlot3 = UseSlot3,

--- a/GGXrdReversalTool/Controls/FrequencyRandomSlotControl.xaml.cs
+++ b/GGXrdReversalTool/Controls/FrequencyRandomSlotControl.xaml.cs
@@ -25,7 +25,6 @@ public sealed partial class FrequencyRandomSlotControl : NotifiedUserControl
         }
     }
 
-    // Using a DependencyProperty as the backing store for GroupName.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty UseSlotProperty =
         DependencyProperty.Register(nameof(UseSlot), typeof(bool), typeof(FrequencyRandomSlotControl),
             new FrameworkPropertyMetadata(false, OnUseSlotPropertyChanged));


### PR DESCRIPTION
Contains following changes:

1. Adds a new checkbox "Play slots in order" that on every reversal first plays slot 1, then slot 2, etc, in order. With an extra checkbox "Reset on stage reset" that resets the order when the stage is reset.
2. A bugfix for a memory corruption caused by writing slots that are too huge. Thanks to @worsety for figuring out this problem!