### PR TITLE
UI fixes and more help for the user on the 'Block Switching' tab

### DIFF
--- a/GGXrdReversalTool/Controls/BlockSwitchingControl.xaml
+++ b/GGXrdReversalTool/Controls/BlockSwitchingControl.xaml
@@ -14,15 +14,18 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <StackPanel Grid.Row="0" Orientation="Horizontal">
-            <TextBlock Text="Block sequence :" VerticalAlignment="Center"/>
-            <Image HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5" Source="../Images/question.png" Height="16"
-                ToolTipService.ToolTip="Block switching works only when you enable the scenario on the 'Scenario' tab using the 'Enable' button.&#10;Warning: crouching stance generates a monotonous '2' (Down) input in the input buffer with the implication that rapid switching to/from crouch produces 22222 inputs that can be interpreted as a special.&#10;Warning: in order for pushback to be consistent with the type of block that was used, all block type changes are applied with a 1 frame delay."/>
-        </StackPanel>
+        <Grid Grid.Row="0" Margin="0,3,0,3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="Block sequence :" VerticalAlignment="Center"/>
+            <Button Grid.Column="1" Content="Help" Width="65" Click="HelpClick"/>
+        </Grid>
         <TextBox x:Name="TextBoxControl" Grid.Row="1" Height="60" Text="{Binding ElementName=Control, Path=BlockSwitchingText, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" IsEnabled="{Binding IsRunning, Converter={StaticResource AntiBooleanConverter}}" SelectionChanged="TextBoxControl_SelectionChanged"/>
         <StackPanel Grid.Row="2" HorizontalAlignment="Center" Margin="0,5,0,0" Orientation="Horizontal" IsEnabled="{Binding IsRunning, Converter={StaticResource AntiBooleanConverter}}">
-            <Button Content="Add New Element" Command="{Binding ElementName=Control, Path=AddNewElementCommand}"/>
-            <Button Content="Edit Current Element" Margin="35,0,0,0" Command="{Binding ElementName=Control, Path=EditCurrentElementCommand}" ToolTipService.ToolTip="The current element is determined by where the text caret is."/>
+            <Button Content="Add New Blocked Hit" Command="{Binding ElementName=Control, Path=AddNewElementCommand}"/>
+            <Button Content="Edit Current Blocked Hit" Margin="35,0,0,0" Command="{Binding ElementName=Control, Path=EditCurrentElementCommand}" ToolTipService.ToolTip="The current element is determined by where the text caret is."/>
             <TextBlock Text="Block hit counter expiry (in frames):" Margin="35,0,5,0" VerticalAlignment="Center"/>
             <local:NumericTextInput Width="60" Text="{Binding ElementName=Control, Path=BlockTimerText, Mode=TwoWay}"/>
             <Image HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5" Source="../Images/question.png" Height="16" ToolTipService.ToolTip="This timer determines for how long after blockstun has ended we treat the next hit as part of the same block sequence.&#10;It also affects the blocked hit counter for Events of type 'Blocked a certain hit' on the 'Scenario' tab.&#10;Default value is 30."/>

--- a/GGXrdReversalTool/Controls/BlockSwitchingControl.xaml.cs
+++ b/GGXrdReversalTool/Controls/BlockSwitchingControl.xaml.cs
@@ -577,9 +577,14 @@ namespace GGXrdReversalTool.Controls
                     + (next.End >= BlockSwitchingText.Length ? string.Empty : BlockSwitchingText.Substring(next.End)),
                 next.Start + element.End - element.Start);
         }
-        
+
+        private void HelpClick(object sender, RoutedEventArgs e)
+        {
+            BlockSwitchingControlHelpWindow helpWindow = new BlockSwitchingControlHelpWindow();
+            helpWindow.Show();
+        }
     }
-    
+
     public struct SplitStringElement
     {
         public int Start;

--- a/GGXrdReversalTool/Controls/BlockSwitchingControlHelpWindow.xaml
+++ b/GGXrdReversalTool/Controls/BlockSwitchingControlHelpWindow.xaml
@@ -1,0 +1,33 @@
+﻿<Window x:Class="GGXrdReversalTool.Controls.BlockSwitchingControlHelpWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:GGXrdReversalTool.Controls"
+        mc:Ignorable="d"
+        x:Name="Control"
+        Title="Block Switching Help" Height="350" Width="400">
+    <Grid Margin="5,5,5,5">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" TextWrapping="Wrap"  Text="You can configure block switching by specifying how the dummy should block each hit, what block type they should use, what stance, etc. You can begin by pressing the 'Add New Blocked Hit' button on the 'Block Switching' tab.&#10;&#10;To enable block switching, you'll need to select some event on the 'Scenario' tab and click the 'Enable' button there to enable the scenario."/>
+        <Button Grid.Row="1" Click="HyperlinkClick" Margin="0,15,0,0">
+            <Button.Template>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <TextBlock Text="{Binding ElementName=Control, Path=HyperlinkText}" Foreground="Blue" TextDecorations="Underline" Cursor="Hand"/>
+                </ControlTemplate>
+            </Button.Template>
+        </Button>
+        <TextBlock Grid.Row="2" Visibility="{Binding ElementName=Control, Path=ShowMoreInfo, Converter={StaticResource VisibilityCollapsedConverter}}"
+            TextWrapping="Wrap"
+            Text="Caveat 1: crouching stance generates a monotonous '2' (Down) input in the input buffer with the implication that rapid switching to/from crouch produces 22222 inputs that can be interpreted as a special.&#10;&#10;Caveat 2: in order for pushback to be consistent with the type of block that was used, all block type changes are applied with a 1 frame delay."/>
+        <Button Grid.Row="3" HorizontalAlignment="Right" Content="Close" Click="CloseClick" Margin="0,3,0,3" Width="80"/>
+    </Grid>
+</Window>

--- a/GGXrdReversalTool/Controls/BlockSwitchingControlHelpWindow.xaml.cs
+++ b/GGXrdReversalTool/Controls/BlockSwitchingControlHelpWindow.xaml.cs
@@ -1,0 +1,56 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+
+namespace GGXrdReversalTool.Controls
+{
+    public partial class BlockSwitchingControlHelpWindow : Window, INotifyPropertyChanged
+    {
+        public BlockSwitchingControlHelpWindow()
+        {
+            InitializeComponent();
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        
+        private bool _showMoreInfo = false;
+        public bool ShowMoreInfo
+        {
+            get => _showMoreInfo;
+            set
+            {
+                if (_showMoreInfo == value) return;
+                _showMoreInfo = value;
+                OnPropertyChanged();
+            }
+        }
+        
+        private string _hyperlinkText = "Show some caveats";
+        public string HyperlinkText
+        {
+            get => _hyperlinkText;
+            set
+            {
+                if (_hyperlinkText.Equals(value)) return;
+                _hyperlinkText = value;
+                OnPropertyChanged();
+            }
+        }
+        
+        private void HyperlinkClick(object sender, RoutedEventArgs e)
+        {
+            ShowMoreInfo = !_showMoreInfo;
+            HyperlinkText = _showMoreInfo ? "Hide caveats" : "Show some caveats";
+        }
+
+        private void CloseClick(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/GGXrdReversalTool/Controls/NewBlockSwitchingElementWindow.xaml
+++ b/GGXrdReversalTool/Controls/NewBlockSwitchingElementWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:GGXrdReversalTool.Controls"
         mc:Ignorable="d"
         x:Name="Control"
-        Title="New Block Element" Height="300" Width="500">
+        Title="Blocked Hit Editor" Height="300" Width="500">
     <Window.Resources>
         <Rectangle x:Shared="false" x:Key="EmptyIcon" Fill="Transparent"/>
         


### PR DESCRIPTION
Changes some UI on the 'Block Switching' tab, namely:

- Renames 'Add New Element' to 'Add New Blocked Hit'.
- Renames 'Edit Current Element' to 'Edit Current Blocked Hit'.
- Replaces the '?' element at the top with a 'Help' button. When you click that button, it shows a new window with textual description of how the 'Block Switching' tab is supposed to be used.
- Renames the title of 'New Block Element' window to 'Blocked Hit Editor'. This is due to the fact that this window is used to both add new block elements and to edit existing ones. The new name fits both use cases.